### PR TITLE
Correct travis branch name

### DIFF
--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 GIT_SHORT_COMMIT=`git rev-parse --short HEAD`
-TRAVIS_BRANCH=`git rev-parse --abbrev-ref HEAD`
 TIMESTAMP=`date -u +%Y%m%d%H`
 TAG="${TRAVIS_BRANCH}-${TIMESTAMP}-${GIT_SHORT_COMMIT}"
 IMAGE_NAME="centrifugeio/centrifuge-ui-kit"


### PR DESCRIPTION
Travis offers a `TRAVIS_BRANCH` variable which signifies which git branch it is executing on