### PR TITLE
Generic Centrifuge Client Mock

### DIFF
--- a/server/src/centrifuge-client/centrifuge-client.mock.ts
+++ b/server/src/centrifuge-client/centrifuge-client.mock.ts
@@ -20,6 +20,27 @@ export class MockCentrifugeService {
         },
       };
     }),
+    create: jest.fn(data => {
+      return {
+        header: {
+          job_id: 'some_job_id',
+        },
+        ...data,
+      };
+    }),
+    update: jest.fn((documentId, data) => {
+      return {
+        header: {
+          job_id: 'some_job_id',
+        },
+        ...data,
+      };
+    }),
+  };
+  purchaseOrders = {
+    create: jest.fn(data => data),
+    get: jest.fn((id, data) => data),
+    update: jest.fn((id, data) => data),
   };
   funding = {
     create: jest.fn((document_id, payload, account) => {
@@ -90,6 +111,35 @@ export class MockCentrifugeService {
         resolve(result);
       });
     }),
+  };
+  invoiceUnpaid = {
+    mintInvoiceUnpaidNFT: () => {
+      return new Promise((resolve, reject) => {
+        resolve({
+              header: {
+                job_id: 'some_job_id',
+              },
+            },
+        );
+      });
+    },
+  };
+  nft = {
+    transferNft: () => {
+      return new Promise((resolve, reject) => {
+        resolve({
+              header: {
+                job_id: 'some_job_id',
+              },
+            },
+        );
+      });
+    },
+  };
+  accounts = {
+    generateAccount: jest.fn(() => ({
+      identity_id: 'generated_identity_id',
+    })),
   }
   pullForJobComplete = () => true;
 }


### PR DESCRIPTION
got rid of redeclared mock Centrifuge Client in each controller package, now single canonical mock.

Closes #241 .

Next PR will export a const `centrifugeServiceProvider` which contains a check for an environmental variable to check if the provider should use a live local node or the mockCentrifugeClient Service.