### PR TITLE
fix: <temp fix> display node address, View document while minting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,8 @@ dist
 
 #database
 db
+
+#osx
+packages/*/.DS_Store
+packages/.DS_Store
+.DS_Store

--- a/packages/server/src/nfts/nfts.controller.ts
+++ b/packages/server/src/nfts/nfts.controller.ts
@@ -58,7 +58,7 @@ export class NftsController {
         },
       });
 
-      if (body.oracle_address === '0x0000000000000000000000000000000000000000') {
+      if (!body.oracle_address || body.oracle_address === '0x0000000000000000000000000000000000000000') {
         console.log('not pushing to oracle', mintingResult)
         return
       }

--- a/packages/server/src/users/users.controller.ts
+++ b/packages/server/src/users/users.controller.ts
@@ -54,7 +54,7 @@ export class UsersController {
 
     try {
       await this.mailerService.sendMail({
-        to: user.email, //user.email,
+        to: user.email,
         subject: 'Centrifuge Gateway Account Verification',
         template: '2fa',
         context: {

--- a/packages/ui/src/documents/ListDocuments.tsx
+++ b/packages/ui/src/documents/ListDocuments.tsx
@@ -112,8 +112,8 @@ export const ListDocuments: FunctionComponent<Props> = (props: Props) => {
     return false
   };
 
-  const displayView = (doc_status: string, nft_status: string) => {
-    return nft_status !==  NftStatus.Minting && doc_status !== DocumentStatus.CreationFail;
+  const displayView = (doc_status: string) => {
+    return doc_status !== DocumentStatus.CreationFail;
   };
 
   return (
@@ -172,7 +172,7 @@ export const ListDocuments: FunctionComponent<Props> = (props: Props) => {
               sortable: false,
               render: datum => (
                 <Box direction="row" gap="small">
-                  {displayView(datum.document_status, datum.nft_status) && <Anchor
+                  {displayView(datum.document_status) && <Anchor
                     label={'View'}
                     onClick={() =>
                       push(

--- a/packages/ui/src/documents/MintNftForm.tsx
+++ b/packages/ui/src/documents/MintNftForm.tsx
@@ -35,6 +35,9 @@ export default class MintNftForm extends React.Component<Props> {
 
   render() {
 
+    console.log(this.state, "STATE IN NFT")
+    console.log(this.props, "PROPS IN NFT")
+
     const { submitted } = this.state;
     const { registries } = this.props;
 

--- a/packages/ui/src/documents/MintNftForm.tsx
+++ b/packages/ui/src/documents/MintNftForm.tsx
@@ -35,9 +35,6 @@ export default class MintNftForm extends React.Component<Props> {
 
   render() {
 
-    console.log(this.state, "STATE IN NFT")
-    console.log(this.props, "PROPS IN NFT")
-
     const { submitted } = this.state;
     const { registries } = this.props;
 

--- a/packages/ui/src/documents/Nfts.tsx
+++ b/packages/ui/src/documents/Nfts.tsx
@@ -114,6 +114,12 @@ export const Nfts: FunctionComponent<Props> = (props) => {
     return actions
   };
 
+  const renderNodeUrl = () => {
+    return window['__ETH_NETWORK__'] === 'kovan' ?
+        <a href={"https://kovan.etherscan.io/address/0x44a0579754D6c94e7bB2c26bFA7394311Cc50Ccb"}>here.</a> :
+        <a href={"https://etherscan.io/address/0x3ba4280217e78a0eaea612c1502fc2e92a7fe5d7"}>here.</a>
+  }
+
   const mintActions = !viewMode ? [
     <Button key="mint-nft" onClick={openMintModal} plain label={'Mint NFT'}/>,
   ] : [];
@@ -123,7 +129,6 @@ export const Nfts: FunctionComponent<Props> = (props) => {
       title="NFTs"
       actions={mintActions}
     >
-
       <DataTableWithDynamicHeight
         size={'360px'}
         sortable={false}
@@ -178,7 +183,8 @@ export const Nfts: FunctionComponent<Props> = (props) => {
       />
 
       {!document!.header!.nfts &&
-      <Paragraph color={'dark-2'}>There are no NFTs minted on this document yet.</Paragraph>}
+      <Paragraph color={'dark-2'}>There are no NFTs minted on this document yet. Pending transactions can be found {renderNodeUrl()}</Paragraph>
+      }
     </Section>);
   };
 

--- a/packages/ui/src/documents/Nfts.tsx
+++ b/packages/ui/src/documents/Nfts.tsx
@@ -116,8 +116,8 @@ export const Nfts: FunctionComponent<Props> = (props) => {
 
   const renderNodeUrl = () => {
     return window['__ETH_NETWORK__'] === 'kovan' ?
-        <a href={"https://kovan.etherscan.io/address/0x44a0579754D6c94e7bB2c26bFA7394311Cc50Ccb"}>here.</a> :
-        <a href={"https://etherscan.io/address/0x3ba4280217e78a0eaea612c1502fc2e92a7fe5d7"}>here.</a>
+        getAddressLink('0x44a0579754D6c94e7bB2c26bFA7394311Cc50Ccb') :
+        getAddressLink('0x3ba4280217e78a0eaea612c1502fc2e92a7fe5d7')
   }
 
   const mintActions = !viewMode ? [
@@ -183,7 +183,7 @@ export const Nfts: FunctionComponent<Props> = (props) => {
       />
 
       {!document!.header!.nfts &&
-      <Paragraph color={'dark-2'}>There are no NFTs minted on this document yet. Pending transactions can be found {renderNodeUrl()}</Paragraph>
+      <Paragraph color={'dark-2'}>There are no NFTs minted on this document yet. Pending transactions can be found {<a href={renderNodeUrl()}>here.</a>}</Paragraph>
       }
     </Section>);
   };

--- a/packages/ui/src/documents/ViewDocument.tsx
+++ b/packages/ui/src/documents/ViewDocument.tsx
@@ -121,7 +121,6 @@ export const ViewDocument: FunctionComponent<Props> = (props: Props) => {
   });
 
   const extendedContacts = extendContactsWithUsers(contacts, [user!]);
-
   return (
     <Box pad={{ bottom: 'large' }}>
       <SecondaryHeader>


### PR DESCRIPTION
Allows Viewing of document while `Minting`

also exposes node address in kovan/mainnet etherscan, depending on ETH_NETWORK

<img width="1157" alt="Screenshot 2020-10-30 at 11 26 31" src="https://user-images.githubusercontent.com/16255463/97694403-ca8a0880-1aa2-11eb-9b7e-78cc5816bfd5.png">


Closes #515 