### PR TITLE
fix: document duplication after updates

### DIFF
--- a/packages/server/src/documents/documents.controller.ts
+++ b/packages/server/src/documents/documents.controller.ts
@@ -82,7 +82,10 @@ export class DocumentsController {
     );
 
     const updatedDocs = await this.databaseService.documents.update(
-      { 'header.document_id': document.header.document_id },
+      {
+        'header.document_id': document.header.document_id,
+        organizationId: user.account.toLowerCase(),
+      },
       {
         $set: {
           document_status:
@@ -137,7 +140,10 @@ export class DocumentsController {
     );
 
     const updated = (await this.databaseService.documents.update(
-      { 'header.document_id': createResult.header.document_id },
+      {
+        'header.document_id': createResult.header.document_id,
+        organizationId: user.account.toLowerCase(),
+      },
       {
         ...createResult,
         attributes: unflatten(createResult.attributes),
@@ -293,7 +299,10 @@ export class DocumentsController {
        * and it can happen that the webhook is not called
        * */
       const docs: any = await this.databaseService.documents.update(
-        { 'header.document_id': docFromNode.header.document_id },
+        {
+          'header.document_id': docFromNode.header.document_id,
+          organizationId: request.user.account.toLowerCase(),
+        },
         {
           $set: {
             attributes: docFromNode.attributes,


### PR DESCRIPTION
### Context

The gateway backend keeps separate documents of the same `document_id` for each user. Users are assinged to documents under the `organizationId` key. If a document is committed by a user, gateway receives a webhook notification from the node for each other user of the same `document_id` and updates the documents of those users in the database. 

### Issue

The `saveDoc` function did not query the document to be updated by `organizationId` (the user that is updating the document), but also did not specify `{ multi: true }` in the update options. Hence is happened in some (but not all) cases that the document for another user was updated. Those updates also changed the `organizationId` during the update to the authenticated user, hereby implicitly duplicating the document for the authenticated user. After the commit, the other user that just lost their document received a webhook notification, creating another copy of the latest version.

As a concrete example, assume we have a document with 2 collaborators (users) A and B. User A tries to update a document, but the update query randomly updates the document of user B in the document, overwriting the ownership (by setting `organizationId`) to user A. At this point, user B has no document in the database, but user A has two copies of the document. User A commits the document, the webhook notification arrives and saves a fresh document for user B. 

### Open

- [x] Remove debugging statements once properly tested. 