### PR TITLE
fix: implement class-transformer to exclude password

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.0",
+    "class-transformer": "^0.4.0",
     "ethereumjs-util": "7.0.5",
     "lodash": "^4.17.19",
     "portable-fetch": "^3.0.0"

--- a/packages/lib/src/models/user.ts
+++ b/packages/lib/src/models/user.ts
@@ -62,6 +62,8 @@ export class PublicUser extends User {
   @Exclude()
   password?: string = '';
   @Exclude()
+  token?: string;
+  @Exclude()
   secret?: TwoFASecret;
 
   constructor(partial: Partial<PublicUser>) {

--- a/packages/lib/src/models/user.ts
+++ b/packages/lib/src/models/user.ts
@@ -37,12 +37,13 @@ export type TwoFASecret = {
 };
 
 export type LoggedInUser = {
-  user: User;
+  user: PublicUser;
   token: string;
 };
 
 export class User implements IUser {
   name: string = '';
+  password?: string = '';
   token?: string;
   email: string = '';
   _id?: string;
@@ -50,17 +51,21 @@ export class User implements IUser {
   chain: IChainAccount;
   permissions: PERMISSIONS[] = [];
   schemas: string[] = [];
+  secret?: TwoFASecret;
   // undefined acts like email in order not run migrations
   twoFAType?: TwoFaType;
   enabled: boolean;
   invited: boolean;
+}
 
+export class PublicUser extends User {
   @Exclude()
   password?: string = '';
   @Exclude()
   secret?: TwoFASecret;
 
-  constructor(partial?: Partial<User>) {
+  constructor(partial: Partial<PublicUser>) {
+    super();
     Object.assign(this, partial);
   }
 }

--- a/packages/lib/src/models/user.ts
+++ b/packages/lib/src/models/user.ts
@@ -1,3 +1,4 @@
+import { Exclude } from 'class-transformer';
 import { PERMISSIONS } from '../utils/constants';
 import { Document, DOCUMENT_ACCESS } from './document';
 import { FundingAgreement } from './funding-request';
@@ -42,7 +43,6 @@ export type LoggedInUser = {
 
 export class User implements IUser {
   name: string = '';
-  password?: string = '';
   token?: string;
   email: string = '';
   _id?: string;
@@ -50,11 +50,19 @@ export class User implements IUser {
   chain: IChainAccount;
   permissions: PERMISSIONS[] = [];
   schemas: string[] = [];
-  secret?: TwoFASecret;
   // undefined acts like email in order not run migrations
   twoFAType?: TwoFaType;
   enabled: boolean;
   invited: boolean;
+
+  @Exclude()
+  password?: string = '';
+  @Exclude()
+  secret?: TwoFASecret;
+
+  constructor(partial?: Partial<User>) {
+    Object.assign(this, partial);
+  }
 }
 
 export class UserWithOrg extends User {

--- a/packages/server/src/app.controller.ts
+++ b/packages/server/src/app.controller.ts
@@ -1,3 +1,4 @@
+import { PublicUser } from '@centrifuge/gateway-lib/models/user';
 import { Controller, Get, Render, Request, Response } from '@nestjs/common';
 import { AppService } from './app.service';
 import config from './config';
@@ -10,7 +11,9 @@ export class AppController {
   @Render('index')
   root(@Request() req, @Response() res) {
     return {
-      preloaderState: this.appService.preloadReduxStore(req.user),
+      preloaderState: this.appService.preloadReduxStore(
+        new PublicUser(req.user),
+      ),
       ethNetwork: config.ethNetwork,
     };
   }

--- a/packages/server/src/app.service.ts
+++ b/packages/server/src/app.service.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@nestjs/common';
-import { User } from '@centrifuge/gateway-lib/models/user';
+import { PublicUser } from '@centrifuge/gateway-lib/models/user';
 
 @Injectable()
 export class AppService {
-  preloadReduxStore(user: User): string {
+  preloadReduxStore(user: PublicUser): string {
     // TODO this can be extended and we can also inject the default homePage for a specific user
     return JSON.stringify({
       user: {

--- a/packages/server/src/auth/auth.module.ts
+++ b/packages/server/src/auth/auth.module.ts
@@ -3,7 +3,6 @@ import { PassportModule } from '@nestjs/passport';
 import { AuthService } from './auth.service';
 import { LocalStrategy } from './local.strategy';
 import { DatabaseModule } from '../database/database.module';
-import { UserManagerAuthGuard } from './user-manager-auth.guard';
 import { TwoFAStrategy } from './2fa.strategy';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtStrategy } from './jwt.strategy';

--- a/packages/server/src/exceptions/all-exception.filter.ts
+++ b/packages/server/src/exceptions/all-exception.filter.ts
@@ -1,14 +1,16 @@
-import { ArgumentsHost, Catch, ExceptionFilter, HttpStatus } from '@nestjs/common';
+import { PublicUser } from '@centrifuge/gateway-lib/models/user';
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from '@nestjs/common';
 import { AppService } from '../app.service';
 import config from '../config';
 
 @Catch()
 export class AllExceptionFilter implements ExceptionFilter {
-
-  constructor(
-    private readonly appService: AppService,
-  ) {
-  }
+  constructor(private readonly appService: AppService) {}
 
   /**
    * Handles all exceptions thrown inside the application
@@ -31,7 +33,9 @@ export class AllExceptionFilter implements ExceptionFilter {
         request.headers.accept.indexOf('text/html') !== -1
       ) {
         return response.render('index', {
-          preloaderState: this.appService.preloadReduxStore(request.user),
+          preloaderState: this.appService.preloadReduxStore(
+            new PublicUser(request.user),
+          ),
           ethNetwork: config.ethNetwork,
         });
       }

--- a/packages/server/src/main.ts
+++ b/packages/server/src/main.ts
@@ -1,9 +1,10 @@
-import { NestFactory } from '@nestjs/core';
+import { NestFactory, Reflector } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as path from 'path';
 import * as passport from 'passport';
 import config from './config';
 import { NestExpressApplication } from '@nestjs/platform-express';
+import { ClassSerializerInterceptor } from '@nestjs/common';
 
 // accept self-signed certificate
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '1';
@@ -13,6 +14,9 @@ async function bootstrap() {
 
   // set up passport
   app.use(passport.initialize());
+
+  // register global interceptor for data serialization (e. g. exclude secrets from DTOs)
+  app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
   // When the build is production the application serves the assets built by create-react-app
   app.setViewEngine('html');

--- a/packages/server/src/users/users.controller.ts
+++ b/packages/server/src/users/users.controller.ts
@@ -1,6 +1,5 @@
 import {
   Body,
-  ClassSerializerInterceptor,
   Controller,
   Delete,
   MethodNotAllowedException,
@@ -12,8 +11,8 @@ import {
   Request,
   UseGuards,
   UseInterceptors,
+  ClassSerializerInterceptor,
 } from '@nestjs/common';
-
 import * as speakeasy from 'speakeasy';
 import * as bcrypt from 'bcrypt';
 import { promisify } from 'util';
@@ -45,7 +44,6 @@ export class UsersController {
     private readonly mailerService: MailerService,
   ) {}
 
-  @UseInterceptors(ClassSerializerInterceptor)
   @Post(ROUTES.USERS.loginTentative)
   @HttpCode(200)
   async loginTentative(@Request() req): Promise<PublicUser> {
@@ -83,7 +81,6 @@ export class UsersController {
     return new PublicUser(user);
   }
 
-  @UseInterceptors(ClassSerializerInterceptor)
   @Post(ROUTES.USERS.login)
   @HttpCode(200)
   async login(@Request() req): Promise<LoggedInUser> {
@@ -108,7 +105,6 @@ export class UsersController {
     };
   }
 
-  @UseInterceptors(ClassSerializerInterceptor)
   @Get('/api/users/profile')
   @UseGuards(JwtAuthGuard)
   async profile(@Request() req): Promise<PublicUser> {
@@ -116,7 +112,6 @@ export class UsersController {
     return new PublicUser(user);
   }
 
-  @UseInterceptors(ClassSerializerInterceptor)
   @Get(ROUTES.USERS.base)
   @UseGuards(JwtAuthGuard, UserManagerAuthGuard)
   async getAllUsers(@Request() request) {
@@ -129,7 +124,6 @@ export class UsersController {
     return users.map(user => new PublicUser(user));
   }
 
-  @UseInterceptors(ClassSerializerInterceptor)
   @Post(ROUTES.USERS.base)
   async register(@Body() user: User) {
     const existingUser: User = await this.databaseService.users.findOne({
@@ -174,7 +168,6 @@ export class UsersController {
     }
   }
 
-  @UseInterceptors(ClassSerializerInterceptor)
   @Post(ROUTES.USERS.invite)
   @UseGuards(JwtAuthGuard, UserManagerAuthGuard)
   async invite(@Body() user: Partial<User>) {
@@ -225,7 +218,6 @@ export class UsersController {
     return newUser;
   }
 
-  @UseInterceptors(ClassSerializerInterceptor)
   @Put(ROUTES.USERS.base)
   @UseGuards(JwtAuthGuard, UserManagerAuthGuard)
   async update(@Body() user): Promise<PublicUser> {

--- a/packages/server/src/users/users.controller.ts
+++ b/packages/server/src/users/users.controller.ts
@@ -1,5 +1,6 @@
 import {
   Body,
+  ClassSerializerInterceptor,
   Controller,
   Delete,
   MethodNotAllowedException,
@@ -11,6 +12,7 @@ import {
   Request,
   Response,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 
 import * as speakeasy from 'speakeasy';
@@ -43,6 +45,7 @@ export class UsersController {
     private readonly mailerService: MailerService,
   ) {}
 
+  @UseInterceptors(ClassSerializerInterceptor)
   @Post(ROUTES.USERS.loginTentative)
   @HttpCode(200)
   async loginTentative(@Request() req): Promise<LoggedInUser> {
@@ -77,10 +80,10 @@ export class UsersController {
         console.log(e);
       }
     }
-
-    return user;
+    return new User(user);
   }
 
+  @UseInterceptors(ClassSerializerInterceptor)
   @Post(ROUTES.USERS.login)
   @HttpCode(200)
   async login(@Request() req): Promise<LoggedInUser> {
@@ -100,7 +103,7 @@ export class UsersController {
       { algorithm: 'RS256', secret: config.jwtPrivKey },
     );
     return {
-      user: req.user,
+      user: new User(req.user),
       token: accessToken,
     };
   }

--- a/packages/server/src/users/users.controller.ts
+++ b/packages/server/src/users/users.controller.ts
@@ -108,11 +108,12 @@ export class UsersController {
     };
   }
 
+  @UseInterceptors(ClassSerializerInterceptor)
   @Get('/api/users/profile')
   @UseGuards(JwtAuthGuard)
-  async profile(@Request() req): Promise<User> {
+  async profile(@Request() req): Promise<PublicUser> {
     let { user } = req;
-    return user;
+    return new PublicUser(user);
   }
 
   @UseInterceptors(ClassSerializerInterceptor)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3737,6 +3737,11 @@ class-is@^1.1.0:
   resolved "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
   integrity sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==
 
+class-transformer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.4.0.tgz#b52144117b423c516afb44cc1c76dbad31c2165b"
+  integrity sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA==
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"


### PR DESCRIPTION
### Description

This pull request adds the [class-transformer](https://github.com/typestack/class-transformer) library as recommended by the [nestjs](https://docs.nestjs.com/techniques/serialization) library in order to exclude specific properties from a class. `password` and `secret` will now be excluded from the network response when a user logins.


~~I did not abstract the exclusion into a sanitization helper since this is the first instance. If we use this functionality repeatedly in the future, it will be clearer as to how we can design a more generic helper.~~

I abstracted the sanitation logic into a `PublicUser` class since this is being used in several places within the users controller.

I tried to implement a unit test to test that the properties were properly excluded, but I found out it is not possible to test for this in unit tests, only in e2e tests. I joined the NestJS discord and found this comment from one of the contributors:

<img width="402" alt="Screen Shot 2021-04-19 at 1 59 23 PM" src="https://user-images.githubusercontent.com/28536523/115297044-565f2200-a121-11eb-9529-330078ab47a8.png">
